### PR TITLE
Modify environment

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -7,7 +7,7 @@ include Makefile.include
 $(LOCKFILE): check_installation .make.bootstrap .make.pip-requirements.txt .make.environment-default.yml .make.conda-forge-requirements.txt
 ifeq (conda, $(VIRTUALENV))
 	$(CONDA_EXE) env update -n $(PROJECT_NAME) -f .make.environment-default.yml --prune
-	$(CONDA_EXE) install -n $(PROJECT_NAME) --file .make.conda-forge-requirements.txt --channel defaults --channel conda-forge --strict-channel-priority --yes
+	$(CONDA_EXE) install -n $(PROJECT_NAME) --file .make.conda-forge-requirements.txt --channel defaults --channel conda-forge 
 	$(CONDA_EXE) run -n $(PROJECT_NAME) --no-capture pip install -r .make.pip-requirements.txt
 	$(CONDA_EXE) env export -n $(PROJECT_NAME) -f $(LOCKFILE)
 else

--- a/environment.yml
+++ b/environment.yml
@@ -40,7 +40,7 @@ dependencies:
   - requests
   - pathlib
   - fsspec
-  - python=3.7
+  - python=3.9
   - psutil
   - cairo
   - pycairo

--- a/scripts/bootstrap.yml
+++ b/scripts/bootstrap.yml
@@ -1,5 +1,5 @@
 channels:
     - defaults
 dependencies:
-    - python=3.7
+    - python=3.9
     - pyyaml


### PR DESCRIPTION
update environment files to a more modern python (3.7 is deprecated) and remove the strict channel order instruction (it's not what we actually want)